### PR TITLE
docs: adopt proper Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1] - 2026-02-10
+
+### Fixed
+
+- Make unix socket non-blocking
+
+## [1.0.0] - 2026-01-12
+
+### Added
+
+- Initial public release of the `ecdysis` library for graceful restarts in Rust
+- GitHub CI pipeline to build and test ecdysis
+- Duplicate job prevention on PRs
+
+### Fixed
+
+- cargo-sort lint issues
+
+[Unreleased]: https://github.com/cloudflare/ecdysis/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/cloudflare/ecdysis/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/cloudflare/ecdysis/releases/tag/v1.0.0


### PR DESCRIPTION
Fixes #3 — adds CHANGELOG.md following [keepachangelog.com](https://keepachangelog.com/en/1.1.0/) format, documenting project history from git log.

## Changes

- Added `CHANGELOG.md` with entries for v1.0.0 and v1.0.1
- Follows Keep a Changelog format with Added, Fixed sections
- Includes comparison links between versions