### PR TITLE
ci: add explicit lint check

### DIFF
--- a/.github/workflows/ecdysis.yml
+++ b/.github/workflows/ecdysis.yml
@@ -34,6 +34,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Build ecdysis
         run: make build
+  lint:
+    needs: skip-duplicate-jobs
+    if: needs.skip-duplicate-jobs.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check formatting and Clippy warnings
+        run: make lint
   test:
     needs: skip-duplicate-jobs
     if: needs.skip-duplicate-jobs.outputs.should_skip != 'true'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ build:
 	$(CARGO) build 
 
 .PHONY: tests
-tests: fmt-check clippy clippy-tests test doc-private
+tests: lint test doc-private
+
+.PHONY: lint
+lint: fmt-check clippy clippy-tests
 
 .PHONY: install-cargo-tools
 install-cargo-tools:
@@ -20,6 +23,7 @@ fmt-check: install-cargo-tools
 .PHONY: clippy
 clippy: install-cargo-tools
 	$(CARGO) clippy -- \
+		--deny warnings \
 		--deny clippy::all \
 		--deny clippy::todo \
 		--deny clippy::unimplemented \

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clippy-tests rustfmt fmt-check
 clippy-tests:
 	cargo clippy --tests -- \
+		--deny warnings \
 		--deny clippy::all \
 		--deny clippy::todo \
 		--deny clippy::unimplemented


### PR DESCRIPTION
Summary:

- Add a first-class `lint` Make target for formatting, `cargo sort --check`, and Clippy checks.
- Add a dedicated GitHub Actions `lint` job so formatting/Clippy failures show up directly in CI.
- Make both library and integration-test Clippy runs fail on any warning with `--deny warnings`.

Verification:

- `actionlint .github\workflows\ecdysis.yml`
- `cargo install cargo-sort --locked`
- `cargo fmt -- --check`
- `cargo sort --check`
- `cargo fmt --manifest-path integration_tests\Cargo.toml -- --check`
- `cargo sort --check integration_tests`
- `git diff --check`

I could not run `make lint` in this Windows workspace because `make` is not installed. I also could not complete the Clippy commands locally because the crate uses Unix-only APIs (`std::os::unix`, Tokio Unix sockets/signals), and this workspace fails before linting; the new CI job runs on `ubuntu-latest`.

Fixes #17.

This was implemented with Codex assistance, with the patch kept focused on the CI lint gate.
