### PR TITLE
docs: adopt Keep a Changelog CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.1] - 2026-04-10
+
+### Fixed
+
+- Cargo.toml formatting
+- Set `O_NONBLOCK` on seqpacket listen socket
+
+### Added
+
+- Export `UnixSeqpacketListenerStream`
+
+## [1.1.0] - 2026-04-09
+
+### Added
+
+- Support for systemd-managed Unix `SOCK_SEQPACKET` sockets
+
+## [1.0.1] - 2026-02-10
+
+### Fixed
+
+- Make unix socket non-blocking
+- Release procedure
+
+### Changed
+
+- Add badges to README
+
+## [1.0.0] - 2026-01-12
+
+### Added
+
+- Initial public release of `ecdysis`
+- GitHub CI pipeline to build and test
+- Graceful restart / socket inheritance (tableflip-inspired)
+
+### Fixed
+
+- cargo-sort lint
+
+### Changed
+
+- Style: cargo fmt, clippy lints
+
+[Unreleased]: https://github.com/cloudflare/ecdysis/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/cloudflare/ecdysis/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/cloudflare/ecdysis/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/cloudflare/ecdysis/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/cloudflare/ecdysis/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ In contrast, `ecdysis` specializes in socket inheritance and rebinding, making i
 
 In summary, `shellflip` is a more user-friendly solution for arbitrary data sharing in `systemd` environments, while `ecdysis` shines when socket inheritance and rebinding are prioritized.
 
+# Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history (Keep a Changelog).
+
 # Contributing
 
 Contributing to `ecdysis` is welcome and encouraged. We appreciate contributions in various forms, including bug reports, feature requests, and pull requests. To ensure that contributions are useful and effective, we have established guidelines that contributors should follow.


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/) and SemVer
- Seed entries from existing `RELEASE_NOTES` history (1.0.0 → 1.1.1)
- Link changelog from README

Closes #3

## Notes
`cliff.toml` / `git-cliff` remain available for automated release note generation; this file is the human-facing changelog requested in the issue.

## Test plan
- [x] Markdown renders on GitHub
- [x] Version compare links point at existing tags